### PR TITLE
Editing for the tomllib PEP

### DIFF
--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -80,7 +80,7 @@ to a Python dict.
 ``parse_float`` is a function that takes a string and returns a float, as with ``json.load``.
 For example, ``decimal.Decimal`` can be used in cases where precision is important.
 
-The returned object contains only basic Python objects (``str``, ``int``,
+The returned object contains only basic Python objects (``str``, ``int``, ``bool``, ``float``,
 ``datetime.{datetime,date,time}``, ``list``, ``dict`` with string keys).
 
 ``tomllib.TOMLDecodeError`` is raised in the case of invalid TOML.
@@ -120,7 +120,7 @@ Petr Viktorin has indicated willingness to maintain a read API,
 <https://discuss.python.org/t/adopting-recommending-a-toml-parser/4068/88>`__.
 
 Rewriting the parser in C is not deemed necessary at this time. It's rare for
-TOML parsing to be a bottleneck in application. Users with higher performance
+TOML parsing to be a bottleneck in applications. Users with higher performance
 needs can use a third party library (as is already often the case with JSON,
 despite a stdlib extension module).
 

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -81,7 +81,8 @@ to a Python dict.
 For example, ``decimal.Decimal`` can be used in cases where precision is important.
 
 The returned object contains only basic Python objects (``str``, ``int``, ``bool``, ``float``,
-``datetime.{datetime,date,time}``, ``list``, ``dict`` with string keys).
+``datetime.{datetime,date,time}``, ``list``, ``dict`` with string keys),
+and the results of `parse_float`.
 
 ``tomllib.TOMLDecodeError`` is raised in the case of invalid TOML.
 
@@ -265,7 +266,22 @@ Using a binary file allows us to a) ensure utf-8 is the encoding used,
 b) avoid incorrectly parsing single carriage returns as valid TOML due to
 universal newlines.
 
-TODO: why does ``tomllib.loads`` take str but not bytes, then??
+Type accepted by the first argument of ``tomllib.loads``
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+While ``tomllib.load`` takes a binary file, ``tomllib.loads`` takes
+a text string. This may seem inconsistent at first.
+
+Quoting TOML v1.0.0 specification:
+
+> A TOML file must be a valid UTF-8 encoded Unicode document.
+
+``tomllib.loads`` does not intend to load a TOML file, but rather the
+document that the file stores. The most natural representation of
+a Unicode document in Python is ``str``, not ``bytes``.
+
+It is possible to add ``bytes`` support in the future if needed, but
+we are not aware of any use cases for it.
 
 Controlling the type of mappings returned by ``tomllib.load[s]``
 ----------------------------------------------------------------

--- a/pep-9999.rst
+++ b/pep-9999.rst
@@ -1,9 +1,8 @@
 PEP: 9999
-Title: Support for parsing TOML in the Standard Library
+Title: tomllib: Support for parsing TOML in the Standard Library
 Author: Taneli Hukkinen, Shantanu Jain <hauntsaninja at gmail.com>
-Sponsor: TODO
-PEP-Delegate: TODO
-Discussions-To: TODO
+Sponsor: Petr Viktorin <encukou@gmail.com>
+Discussions-To: https://discuss.python.org/t/adopting-recommending-a-toml-parser/4068
 Status: Draft
 Type: Standards Track
 Content-Type: text/x-rst
@@ -16,7 +15,8 @@ Abstract
 ========
 
 This proposes adding a module, ``tomllib``, to the standard library for
-parsing TOML. [1]_
+parsing TOML (Tom's Obvious Minimal Language,
+`https://toml.io <https://toml.io/en/>`_).
 
 
 Motivation
@@ -46,7 +46,8 @@ Rationale
 =========
 
 This PEP proposes basing the standard library support for reading TOML on the
-third party library ``tomli`` [2]_.
+third party library ``tomli``
+(`github.com/hukkin/tomli <https://github.com/hukkin/tomli>`_).
 
 Many projects have recently switched to using ``tomli``, for example, ``pip``,
 ``build``, ``pytest``, ``mypy``, ``black``, ``flit``, ``coverage``,
@@ -54,30 +55,37 @@ Many projects have recently switched to using ``tomli``, for example, ``pip``,
 
 ``tomli`` is actively maintained and well-tested. ``tomli`` is about 800 lines
 of code with 100% test coverage and passes all tests in a test suite `proposed as
-the official TOML compliance test suite <https://github.com/toml-lang/compliance/pull/8>`,
-as well as `the more established BurntSushi/toml-test suite <https://github.com/BurntSushi/toml-test>`.
+the official TOML compliance test suite <https://github.com/toml-lang/compliance/pull/8>`_,
+as well as `the more established BurntSushi/toml-test suite <https://github.com/BurntSushi/toml-test>`_.
 
 
 Specification
 =============
+
+A new module ``tomllib`` with the following functions will be added:
 
 .. code-block::
 
    def load(fp: SupportsRead[bytes], /, *, parse_float: Callable[[str], Any] = float) -> dict[str, Any]: ...
    def loads(s: str, /, *, parse_float: Callable[[str], Any] = float) -> dict[str, Any]: ...
 
-``tomllib.load`` deserializes a ``.read()``-supporting binary file containing a
-TOML document to a Python object.
+``tomllib.load`` deserializes a binary file containing a
+TOML document to a Python dict.
+The ``fp`` argument must have a ``read()`` method with the same API as
+``io.RawIOBase.read()``.
 
-``tomllib.loads`` deserializes a str instance containing a TOML document to a
-Python object.
+``tomllib.loads`` deserializes a str instance containing a TOML document
+to a Python dict.
 
 ``parse_float`` is a function that takes a string and returns a float, as with ``json.load``.
-For example, ``decimal.Decimal`` in cases where precision is important.
+For example, ``decimal.Decimal`` can be used in cases where precision is important.
+
+The returned object contains only basic Python objects (``str``, ``int``,
+``datetime.{datetime,date,time}``, ``list``, ``dict`` with string keys).
 
 ``tomllib.TOMLDecodeError`` is raised in the case of invalid TOML.
 
-Note that we currently do not propose ``tomllib.dump`` or ``tomllib.dumps``
+Note that this PEP does not propose ``tomllib.dump`` or ``tomllib.dumps``
 functions, see `<Including an API for writing TOML_>`_ for details.
 
 
@@ -105,17 +113,16 @@ weighs under 1000 lines of code. It is minimalist, offering a smaller API
 surface area than other TOML implementations.
 
 The author of ``tomli`` is willing to help integrate ``tomli`` into the standard
-library and help maintain it, `as per this
+library and help maintain it, `as per this post
 <https://github.com/hukkin/tomli/issues/141#issuecomment-998018972>`__.
-One CPython core dev has indicated willingness to maintain a read API,
-`as per this
+Petr Viktorin has indicated willingness to maintain a read API,
+`as per this post
 <https://discuss.python.org/t/adopting-recommending-a-toml-parser/4068/88>`__.
 
-There is unlikely to be demand for an extension module, since there is
-relatively less need for performance in parsing TOML: it's rare for application
-bottleneck to be reading configuration. Users with extreme performance needs can
-use a third party library (as is already often the case with JSON, despite a
-stdlib extension module).
+Rewriting the parser in C is not deemed necessary at this time. It's rare for
+TOML parsing to be a bottleneck in application. Users with higher performance
+needs can use a third party library (as is already often the case with JSON,
+despite a stdlib extension module).
 
 TOML support a slippery slope for other things
 ----------------------------------------------
@@ -127,13 +134,20 @@ other formats, such as YAML or MessagePack.
 In addition, the simplicity of TOML can help serve as a dividing line, for
 example, YAML is large and complicated.
 
+Including an API for writing TOML may, however, be added in a future PEP.
+
 
 Backwards Compatibility
 =======================
 
-This will have no backwards compatibility issues as it will create a new API.
+This proposal has no backwards compatibility issues within the stdlib, as it
+describes a new module.
+Any existing third-party module named ``tomllib`` will break, as
+``import tomllib`` will import standard library module.
+However, ``tomllib`` is not registered on PyPI, so it is unlikely that such
+a module is widely used.
 
-Note that we avoid using the ``toml`` name for the module, to avoid backwards
+Note that we avoid using the more straightforward name ``toml``, to avoid backwards
 compatibility implications for users who have pinned versions of the current
 ``toml`` PyPI package. For more details, see `<Alternative names for module_>`_.
 
@@ -141,8 +155,11 @@ compatibility implications for users who have pinned versions of the current
 Security Implications
 =====================
 
-Errors in the implementation could cause potential security issues. However, the
-implementation will be in pure Python, which reduces surface area of attack.
+Errors in the implementation could cause potential security issues.
+The parser's output is limited to simple data types; inability to load
+arbitrary classes avoids security issues common in more "powerful" formats like
+pickle and YAML. Also, the implementation will be in pure Python, which reduces
+security issues endemic to C, such as buffer overflows.
 
 
 How to Teach This
@@ -150,6 +167,9 @@ How to Teach This
 
 The API of ``tomllib`` mimics that of other well-established file format libraries,
 such as ``json`` and ``pickle``.
+The lack of a ``dump`` function will be explained in the documentation,
+with a link to relevant third-party libraries (``tomlkit``, ``pytomlpp``,
+``rtoml``, ``tomli-w``).
 
 
 Reference Implementation
@@ -162,26 +182,6 @@ https://github.com/hukkin/tomli
 
 Rejected Ideas
 ==============
-
-Roundtripping style
--------------------
-
-In general, ``tomllib.dumps(tomllib.loads(x))`` may not equal the same string as
-``x``, since we make no effort to preserve comments, whitespace or other
-stylistic choices.
-
-Style preservation would allow tools to losslessly edit TOML files. Since TOML
-is intended as human-readable and human-editable configuration, it's important
-to preserve human markup.
-
-However, only a relatively small fraction of use cases require losslessly
-editing TOML, as judged by reverse dependencies the style preserving ``tomlkit``
-library compared to that of other third party toml libraries. In particular, we
-don't need it for the core Python packaging use cases or for tools that merely
-need to read configuration.
-
-Since this would make both the implementation and the API more complex, it seems
-better to relegate this additional functionality to third party libraries.
 
 Basing on another TOML implementation
 -------------------------------------
@@ -224,37 +224,26 @@ The ability to write TOML is not needed for the use cases that motivate this
 PEP: for core Python packaging use cases or for tools that need to read
 configuration.
 
-As discussed in the previous section, use cases that involve editing TOML (as
-opposed to writing brand new TOML) are better served by a style preserving
-library.
+Use cases that involve editing TOML (as opposed to writing brand new TOML)
+are better served by a style preserving library. This requires a parser whose
+output includes style-related metadata, making it impractical to output plain
+Python types like ``str`` and ``dict``. Designing such an API is complicated.
 
-There are several degrees of freedom in how to design a write API. For example,
+But even without considering style preservation, there are too many degrees of
+freedom in how to design a write API. For example,
 how much control to allow users over output formatting, over serialization of
 custom types, and over input and output validation. While there are reasonable
 choices on how to resolve these, the nature of the standard library is such that
-one only gets one chance to get things right. See `Appendix B`_. for an overview
-of some of the design questions.
+one only gets one chance to get things right.
 
 Currently no CPython core developers have expressed willingness to maintain a
 write API or sponsor a PEP that includes a write API. Since it is hard to change
 or remove something in the standard library, it is safer to err on the side of
 exclusion and potentially revisit later.
 
-That said, here are reasons to include an API for writing TOML:
-
-Users will likely expect a write API to be available for consistency.
-
-Empirically, writing TOML seems useful. On https://grep.app, there are about
-1.3k hits for "toml.load" and "tomli.load", compared to about 400 hits for
-"toml.dump" and "tomli_w.dump".
-
-Even a simple API is capable of serving common use cases, such as testing code
-that loads TOML or writing out simple or boilerplate TOML.
-TODO: estimate prevalence of simple use cases
-
-If we keep feature set narrow, a write API shouldn't be too much additional
-burden. The fairly minimal implementation in ``tomli-w`` is about 200 lines
-of code.
+So, writing TOML is left to third-party libraries.
+If a good API and relevant use cases for it are found later, it can be added
+in a future PEP.
 
 
 Assorted API details
@@ -268,43 +257,50 @@ objects, ignoring missing files and merging the documents into a single object).
 Doing this would be inconsistent with ``json.load``, ``pickle.load``, etc. If we
 agree consistency with other stdlib modules is desirable, allowing paths is
 somewhat out of scope for this PEP. This can easily and explicitly be worked
-around in user code.
+around in user code, or a third-party library.
 
-The proposed API takes a ``SupportsRead[bytes]``, while ``toml.load`` takes a
-``SupportsRead[str]`` and ``json.load`` takes ``SupportsRead[str | bytes]``.
-Using ``SupportsRead[bytes]`` allows us to a) ensure utf-8 is the encoding used,
+The proposed API takes a binary file, while ``toml.load`` takes a
+text file and ``json.load`` takes either.
+Using a binary file allows us to a) ensure utf-8 is the encoding used,
 b) avoid incorrectly parsing single carriage returns as valid TOML due to
 universal newlines.
 
+TODO: why does ``tomllib.loads`` take str but not bytes, then??
+
 Controlling the type of mappings returned by ``tomllib.load[s]``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+----------------------------------------------------------------
 
-This would work similarly to common uses for the ``object_hook`` argument in
-``json.load[s]``.
-
-Such an argument is not necessary for the core use cases outlined in the
-motivation section. The absence of this can be pretty easily worked around using
-a wrapper class or transformer function. Finally, support could be added later
-in a backward compatible way.
-
-The ``toml`` library on PyPI supports this feature using the ``_dict`` argument.
-There are several uses of this on https://grep.app, however, almost all of them
-were passing ``_dict=OrderedDict``, which should be unnecessary as of Python
-3.7. There were two instances of legitimate use: in one case, a custom class was
+The ``toml`` library on PyPI supports a ``_dict`` argument, which works
+similarly to the ``object_hook`` argument in ``json.load[s]``. There are
+several uses of ``_dict`` found on https://grep.app, however, almost all of them
+are passing ``_dict=OrderedDict``, which should be unnecessary as of Python
+3.7. We found two instances of legitimate use: in one case, a custom class was
 passed for friendlier KeyErrors, in another case, the custom class had several
 additional lookup and mutation methods (e.g. to help resolve dotted keys).
 
+Such an argument is not necessary for the core use cases outlined in the
+motivation section. The absence of this can be pretty easily worked around using
+a wrapper class, transformer function, or a third-party library. Finally,
+support could be added later in a backward compatible way.
+
+
 Removing support for ``parse_float`` in ``tomllib.load[s]``
-^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+-----------------------------------------------------------
 
 This option is not strictly necessary, since TOML floats are "IEEE 754 binary64
-values", which is ``float``. Using ``decimal.Decimal`` thus allows users extra
+values", which is ``float`` on most architectures. Using ``decimal.Decimal``
+thus allows users extra
 precision not promised by the TOML format. However, in the author of ``tomli``'s
 experience, this is useful in scientific and financial applications. TOML-facing
 users may include non-developers who are not aware of the limits of
 double-precision float.
 
 TODO: user quotes
+
+There are also niche architectures where the Python ``float`` is not a IEEE-754
+binary64. The ``parse_float`` argument allows users to achieve correct TOML
+semantics even on such architectures.
+
 
 Alternative names for module
 ----------------------------
@@ -324,19 +320,7 @@ would likely be a common response to breaking changes introduced by repurposing
 the ``toml`` package as a backport (that is incompatible with today's ``toml``).
 
 There are several API incompatibilities between ``toml`` and the API proposed in
-this PEP. Here are the differences that a significant fraction of users are
-likely to run into:
-
-* Use of ``toml.dump`` and ``toml.dumps``, since this PEP does not propose
-  an API for writing TOML.
-* ``toml.load`` accepts a non-overlapping set of types from the proposed API for
-  ``tomllib.load``. See `here <Types accepted by the first argument of
-  tomllib.load_>`_ for the rationale.
-* For invalid TOML, ``toml`` raises ``toml.TomlDecodeError`` vs the proposed
-  :pep:`8` compliant ``tomllib.TOMLDecodeError``.
-
-There are other minor or less widely used API differences. If interested, refer
-to `Appendix A`_ for a more complete listing.
+this PEP, listed in `Appendix A`_.
 
 Finally, the ``toml`` package on PyPI is not actively maintained and `we have
 been unable to contact the author <https://github.com/uiri/toml/issues/361>`,
@@ -346,12 +330,12 @@ This PEP proposes ``tomllib``. This mirrors ``plistlib`` (another file format
 module in the standard library), as well as several others such as ``pathlib``,
 ``graphlib``, etc.
 
-Other bikesheds include:
+Other considered names include:
 
 * ``tomlparser``. This mirrors ``configparser``, but is perhaps slightly less
   appropriate if we include a write API in the future.
 * ``tomli``. This assumes we use ``tomli`` as the basis for implementation.
-* ``toml``, but under some namespace, such as ``parser.toml``. However, this is
+* ``toml`` under some namespace, such as ``parser.toml``. However, this is
   awkward, especially so since existing libraries like ``json``, ``pickle``,
   ``marshal``, ``html`` etc. would not be included in the namespace.
 
@@ -372,22 +356,6 @@ Useful https://grep.app searches (note, ignore vendored):
 * toml.load[s] usage https://grep.app/search?q=toml.load&filter[lang][0]=Python
 * toml.dump[s] usage https://grep.app/search?q=toml.dump&filter[lang][0]=Python
 * TomlEncoder subclasses https://grep.app/search?q=TomlEncoder%29%3A&filter[lang][0]=Python
-
-
-References
-==========
-
-.. [1]
-   TOML: Tom's Obvious Minimal Language
-   https://toml.io/en/
-
-.. [2]
-   tomli
-   https://github.com/hukkin/tomli
-
-.. [3]
-   tomli-w
-   https://github.com/hukkin/tomli-w
 
 
 .. _Appendix A:
@@ -497,86 +465,6 @@ space. Note that this list might not be exhaustive.
    ``toml`` uses and exposes custom ``toml.tz.TomlTz`` timezone objects. The
    proposed implementation uses ``datetime.timezone`` objects from the standard
    library.
-
-
-.. _Appendix B:
-
-Appendix B: Designing a write API
-=================================
-
-This appendix discusses some of the degrees of freedom in the design space of
-write APIs. This list is not exhaustive.
-
-
-Providing users control over formatting
----------------------------------------
-
-Values in TOML can be represented in multiple ways. This is a feature of TOML:
-it allows users to phrase things to maximize subjective readability.
-Inevitably, people will have strong opinions over how to do so.
-
-Here is a non-exhaustive list of potential options users may want control over:
-
-* How much to indent
-* How to format strings (single-line or multiple-line, basic or literal)
-* Whether newline sequences should be normalized (perhaps depending on ``os.linesep``)
-* When to inline arrays or tables
-* Whether to reorder contents
-* Whether to use dotted keys
-
-This isn't hypothetical, there are several instances in open source code of
-users attempting to achieve TOML output with a given formatting.
-
-The ``tomli-w`` library contains only one option to customise output formatting:
-controlling whether strings containing newlines are written as multiline
-strings. This option is a little tricky (and so defaults to False),
-since it loses semantics that guarantee the bytes in newline sequences, for
-instance in the case of ``tomli_w.dumps(tomli.loads(r'''s = "\r\n"'''),
-multiline_strings=True)``
-
-The ``toml`` library supports output formatting using custom subclasses of
-``toml.TomlEncoder``. However, the API exposes a lot of implementation detail,
-essentially allowing users to override parts of the TOML writing process. See
-`here
-<https://github.com/uiri/toml/blob/3f637dba5f68db63d4b30967fedda51c82459471/toml/encoder.pyi#L9>`__.
-
-The ``tomlkit`` library is fully style preserving and allows users to specify
-the exact output they want using an imperative document construction API.
-
-It remains an option to make output mostly non-customizable, which should
-maximizes forwards compatibility. In addition, in several cases users could
-choose to enforce TOML formatting by using an autoformatter of their choice at a
-later point.
-
-
-Providing users control over serialization
-------------------------------------------
-
-It needs to be determined which types can be serialized to TOML out of the box.
-For instance, ``tomli-w`` supports dumping ``decimal.Decimal``, while ``toml``
-does not.
-
-It could be useful to add the equivalent of the ``default`` argument in ``json.dump``
-to allow users to specify how custom types should be serialized.
-
-The ``toml`` library on PyPI supports this using subclasses of
-``toml.TomlEncoder``. However, this functionality seems not often used in
-practice. TOML is used more for configuration than serialization of arbitrary
-data, so users are perhaps less likely to require custom serialization than with
-say JSON.
-
-It would be easy to add support for this later in a backward compatible way.
-
-
-Providing users control over validation
----------------------------------------
-
-TODO
-
-Should we guarantee that either output TOML is valid or an error is raised?
-(``tomli-w`` does not have this guarantee)
-
-Should we detect circular references? (``toml``does, but ``tomli-w`` does not)
 
 
 Copyright


### PR DESCRIPTION

- title: I'd like if people said "the tomllib PEP" rather than "PEP 31415926"
- numbered references are annoying, you need to scroll around too much
- the `SupportsRead` type is specific to tomli, right?
- discussions on a write/roundtrip API are best left to a future PEP
- TODO: why does ``tomllib.loads`` take str but not bytes, then??